### PR TITLE
Sunik feature questions answers

### DIFF
--- a/client/src/components/QA/QA.scss
+++ b/client/src/components/QA/QA.scss
@@ -122,10 +122,10 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
-    color: rgb(121, 121, 121);
     font-size: .7rem;
     margin-bottom: 1rem;
     margin-left: 1.45rem;
+    color: #292929;
   }
 
   .author-date {
@@ -140,10 +140,9 @@
     flex-direction: row;
     flex-wrap: nowrap;
     justify-content: flex-end;
-    color: rgb(121, 121, 121);
     font-size: .7rem;
     margin-bottom: 1rem;
-
+    color: #292929;
   }
 
   .load-more-answers {


### PR DESCRIPTION
- just changed the text color to boost accessibility score
- for the other main accessibility issue ("Heading elements are not in a sequentially-descending order"): Lighthouse flags my search bar, but I did a search of the whole repo and the actual h4 header they're trying to flag is in the ProductExtra.jsx file (there are no headers in my search bar). So that file might need to be changed to fix that issue. 
<img width="463" alt="h4 header" src="https://user-images.githubusercontent.com/73491454/129257560-e586269e-c5ed-42ad-93a1-64b9c8e340a1.png">
