### PR TITLE
Sunik code splitting

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     index: './client/src/index.js',
     app: './client/src/components/App/App.jsx',
     header: './client/src/components/Header/Header.jsx',
-    questions: './client/src/components/QA/QuestionsAndAnswers.jsx',
+    questions: ['./client/src/components/QA/QuestionsAndAnswers.jsx', './client/src/components/QA/AnswerModal.jsx', './client/src/components/QA/QuestionModal.jsx'],
     productOverview: './client/src/components/ProductOverview/ProductOverview.jsx',
     reviews: './client/src/components/Reviews/RatingsAndReviews.jsx',
     stars: '/client/src/components/Stars/Stars.jsx'
@@ -50,7 +50,7 @@ module.exports = {
   },
   optimization: {
     splitChunks: {
-      chunks: 'all',
+      chunks: 'initial',
     }
   },
   plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,15 @@ const zlib = require('zlib');
 
 
 module.exports = {
-  entry: path.resolve(__dirname, '/client/src/index.js'),
+  entry: {
+    index: './client/src/index.js',
+    app: './client/src/components/App/App.jsx',
+    header: './client/src/components/Header/Header.jsx',
+    questions: './client/src/components/QA/QuestionsAndAnswers.jsx',
+    productOverview: './client/src/components/ProductOverview/ProductOverview.jsx',
+    reviews: './client/src/components/Reviews/RatingsAndReviews.jsx',
+    stars: '/client/src/components/Stars/Stars.jsx'
+  },
   module: {
     rules: [
       {
@@ -37,26 +45,31 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'client/public'),
-    filename: 'bundle-[contenthash].bundle.js',
+    filename: '[name].bundle-[contenthash].bundle.js',
     clean: true
   },
-  plugins:
-  [new CompressionPlugin({
-    filename: '[path][base].br',
-    algorithm: 'brotliCompress',
-    test: /\.(jsx|js|css|html|svg)$/,
-    compressionOptions: {
-      params: {
-        [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    }
+  },
+  plugins: [
+    new CompressionPlugin({
+      filename: '[path][base].br',
+      algorithm: 'brotliCompress',
+      test: /\.(jsx|js|css|html|svg)$/,
+      compressionOptions: {
+        params: {
+          [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+        },
       },
-    },
-    threshold: 10240,
-    minRatio: 0.8,
-    deleteOriginalAssets: false,
-  }),
-  new HtmlWebpackPlugin({
-    template: __dirname + '/client/src/template.html',
-    favicon: './client/src/favicon.ico',
-    inject: 'body'
-  })],
+      threshold: 10240,
+      minRatio: 0.8,
+      deleteOriginalAssets: false,
+    }),
+    new HtmlWebpackPlugin({
+      template: __dirname + '/client/src/template.html',
+      favicon: './client/src/favicon.ico',
+      inject: 'body'
+    })],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
   },
   optimization: {
     splitChunks: {
-      chunks: 'initial',
+      chunks: 'all',
     }
   },
   plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
     header: './client/src/components/Header/Header.jsx',
     questions: ['./client/src/components/QA/QuestionsAndAnswers.jsx', './client/src/components/QA/AnswerModal.jsx', './client/src/components/QA/QuestionModal.jsx'],
     productOverview: './client/src/components/ProductOverview/ProductOverview.jsx',
-    reviews: './client/src/components/Reviews/RatingsAndReviews.jsx',
+    reviews: ['./client/src/components/Reviews/RatingsAndReviews.jsx', './client/src/components/Reviews/NewReviewForm.jsx', './client/src/components/Reviews/ReviewsModal.jsx'],
     stars: '/client/src/components/Stars/Stars.jsx'
   },
   module: {


### PR DESCRIPTION
- on lighthouse, the code-split version performs identically or slightly better (1-2 points on desktop) than the non-split version. basically identical.
- as discussed in slack, our app won't benefit that much from code-splitting, but there might be some benefits in splitting because some of the bundles may be cached in the user's browser and won't need to be reloaded on future visits.
- it's a super easy thing to change if we want to change it back for any reason (all splitting happens in the webpack.config.js file)